### PR TITLE
Add suppress_lgtm opt-in to skip pure-LGTM comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,8 @@ Bonk is configured via your workflow file and OpenCode's config. Its built-in ha
 | `model`              | Model to use (e.g., `opencode/claude-opus-4-5`)                                  | Yes      |
 | `mentions`           | Comma-separated triggers (e.g., `/bonk,@ask-bonk`)                               | No       |
 | `permissions`        | Required permission: `admin`, `write`, `any`, or `CODEOWNERS`                    | No       |
+| `forks`              | Post a 'not supported' comment on fork PRs (`"true"` / `"false"`)                | No       |
+| `suppress_lgtm`      | Post no comment on reviews with no actionable findings (`"true"` / `"false"`)    | No       |
 | `token_permissions`  | Scope the installation token: `NO_PUSH`, `WRITE`, or JSON                        | No       |
 | `opencode_version`   | Pin to a specific OpenCode version (e.g., `"1.2.16"`). Defaults to `"latest"`.   | No       |
 | `opencode_dev`       | Install from the dev channel instead of latest release (`"true"` / `"false"`)    | No       |

--- a/github/action.yml
+++ b/github/action.yml
@@ -37,6 +37,11 @@ inputs:
     required: false
     default: "true"
 
+  suppress_lgtm:
+    description: "Post no comment on reviews with no actionable findings. Set to 'true' to suppress the default LGTM! comment."
+    required: false
+    default: "false"
+
   variant:
     description: "Model variant for provider-specific reasoning effort (e.g., high, max, minimal)"
     required: false
@@ -141,6 +146,8 @@ runs:
         HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         # fork-comment
         FORKS: ${{ inputs.forks }}
+        # lgtm suppression
+        SUPPRESS_LGTM: ${{ inputs.suppress_lgtm }}
         ACTOR: ${{ github.event.comment.user.login || github.event.review.user.login || github.actor }}
         # track
         GITHUB_RUN_ID: ${{ github.run_id }}

--- a/github/script/orchestrate.ts
+++ b/github/script/orchestrate.ts
@@ -742,13 +742,7 @@ export async function buildPrompt(): Promise<PromptResult> {
     `<bonk_user_request>\n${escapePromptValue(userRequest)}\n</bonk_user_request>`,
   ];
 
-  // suppress_lgtm: on standalone reviews, tell OpenCode to post nothing when a
-  // review has no actionable findings, instead of the default `LGTM!`. The
-  // hidden HTML marker keeps the final response non-empty (so opencode github
-  // run still delivers it like today) while rendering invisibly on GitHub,
-  // mirroring the fork-unsupported marker used in handleFork below. Inline
-  // review-thread replies are excluded: a human asked a question and expects an
-  // answer, not an empty comment.
+  // With suppress_lgtm, a review with no findings returns a hidden marker so no visible comment posts; thread replies still get answers.
   const isReviewEvent = process.env.EVENT_NAME === "pull_request_review";
   if (process.env.SUPPRESS_LGTM === "true" && isReviewEvent) {
     promptParts.push(

--- a/github/script/orchestrate.ts
+++ b/github/script/orchestrate.ts
@@ -737,14 +737,34 @@ export async function buildPrompt(): Promise<PromptResult> {
   if (headSha) contextLines.push(`head_sha: ${escapePromptValue(headSha)}`);
   contextLines.push("</bonk_execution_context>");
 
+  const promptParts = [
+    contextLines.join("\n"),
+    `<bonk_user_request>\n${escapePromptValue(userRequest)}\n</bonk_user_request>`,
+  ];
+
+  // suppress_lgtm: on standalone reviews, tell OpenCode to post nothing when a
+  // review has no actionable findings, instead of the default `LGTM!`. The
+  // hidden HTML marker keeps the final response non-empty (so opencode github
+  // run still delivers it like today) while rendering invisibly on GitHub,
+  // mirroring the fork-unsupported marker used in handleFork below. Inline
+  // review-thread replies are excluded: a human asked a question and expects an
+  // answer, not an empty comment.
+  const isReviewEvent = process.env.EVENT_NAME === "pull_request_review";
+  if (process.env.SUPPRESS_LGTM === "true" && isReviewEvent) {
+    promptParts.push(
+      "<bonk_instruction>suppress_lgtm is enabled: if this review finds no actionable issues, " +
+        "do not return 'LGTM!'. Return exactly the hidden HTML comment " +
+        "'<!-- bonk: no actionable findings -->' as the final text so no visible comment posts. " +
+        "Only return a normal final response when there are actual nits, issues, or warnings to report." +
+        "</bonk_instruction>",
+    );
+  }
+
   return {
     isFork: detection.isFork,
     detectionFailed: detection.detectionFailed ?? false,
     mode,
-    value: [
-      contextLines.join("\n"),
-      `<bonk_user_request>\n${escapePromptValue(userRequest)}\n</bonk_user_request>`,
-    ].join("\n\n"),
+    value: promptParts.join("\n\n"),
   };
 }
 

--- a/test/github-script.spec.ts
+++ b/test/github-script.spec.ts
@@ -130,6 +130,107 @@ describe("GitHub Action preflight prompt", () => {
     );
   });
 
+  it("adds the suppression directive on standalone reviews when suppress_lgtm is enabled", async () => {
+    const result = await withEnv(
+      {
+        EVENT_NAME: "pull_request_review",
+        USER_PROMPT: undefined,
+        COMMENT_BODY: undefined,
+        REVIEW_BODY: "/bonk",
+        MENTIONS: "/bonk,@ask-bonk",
+        PR_NUMBER: "12",
+        ISSUE_NUMBER: "12",
+        REPOSITORY: "owner/repo",
+        PR_HEAD_REPO: "owner/repo",
+        PR_BASE_REPO: "owner/repo",
+        PR_URL: undefined,
+        GH_TOKEN: undefined,
+        HEAD_SHA: undefined,
+        TOKEN_PERMISSIONS: undefined,
+        SUPPRESS_LGTM: "true",
+      },
+      () => buildPrompt(),
+    );
+
+    expect(result.value).toContain("suppress_lgtm is enabled");
+    expect(result.value).toContain("<!-- bonk: no actionable findings -->");
+    expect(result.value).toContain("do not return 'LGTM!'");
+  });
+
+  it("keeps the default behavior when suppress_lgtm is absent", async () => {
+    const result = await withEnv(
+      {
+        EVENT_NAME: "pull_request_review",
+        USER_PROMPT: undefined,
+        COMMENT_BODY: undefined,
+        REVIEW_BODY: "/bonk",
+        MENTIONS: "/bonk,@ask-bonk",
+        PR_NUMBER: "12",
+        ISSUE_NUMBER: "12",
+        REPOSITORY: "owner/repo",
+        PR_HEAD_REPO: "owner/repo",
+        PR_BASE_REPO: "owner/repo",
+        PR_URL: undefined,
+        GH_TOKEN: undefined,
+        HEAD_SHA: undefined,
+        TOKEN_PERMISSIONS: undefined,
+        SUPPRESS_LGTM: undefined,
+      },
+      () => buildPrompt(),
+    );
+
+    expect(result.value).not.toContain("suppress_lgtm is enabled");
+  });
+
+  it("does not add the suppression directive on inline review-thread replies", async () => {
+    const result = await withEnv(
+      {
+        EVENT_NAME: "pull_request_review_comment",
+        USER_PROMPT: undefined,
+        COMMENT_BODY: "/bonk why does this fail",
+        REVIEW_BODY: undefined,
+        MENTIONS: "/bonk,@ask-bonk",
+        PR_NUMBER: "12",
+        ISSUE_NUMBER: "12",
+        REPOSITORY: "owner/repo",
+        PR_HEAD_REPO: "owner/repo",
+        PR_BASE_REPO: "owner/repo",
+        PR_URL: undefined,
+        GH_TOKEN: undefined,
+        HEAD_SHA: undefined,
+        TOKEN_PERMISSIONS: undefined,
+        SUPPRESS_LGTM: "true",
+      },
+      () => buildPrompt(),
+    );
+
+    expect(result.value).not.toContain("suppress_lgtm is enabled");
+  });
+
+  it("does not add the suppression directive on non-review events", async () => {
+    const result = await withEnv(
+      {
+        EVENT_NAME: "issue_comment",
+        USER_PROMPT: undefined,
+        COMMENT_BODY: "/bonk summarize this issue",
+        REVIEW_BODY: undefined,
+        MENTIONS: "/bonk,@ask-bonk",
+        PR_NUMBER: undefined,
+        ISSUE_NUMBER: "42",
+        REPOSITORY: "owner/repo",
+        PR_HEAD_REPO: undefined,
+        PR_BASE_REPO: undefined,
+        PR_URL: undefined,
+        GH_TOKEN: undefined,
+        TOKEN_PERMISSIONS: undefined,
+        SUPPRESS_LGTM: "true",
+      },
+      () => buildPrompt(),
+    );
+
+    expect(result.value).not.toContain("suppress_lgtm is enabled");
+  });
+
   it.each([
     { label: "omitted action input", tokenPermissions: "", contents: "write" },
     { label: "WRITE preset", tokenPermissions: "WRITE", contents: "write" },


### PR DESCRIPTION
Adds an opt-in `suppress_lgtm` input. When set to `true`, Bonk posts nothing if a review finds no actionable issues, instead of the usual `LGTM!`. Off by default.

- `github/action.yml`: new `suppress_lgtm` input (default `"false"`) and `SUPPRESS_LGTM` env passthrough to the preflight step.
- `github/script/orchestrate.ts`: on a standalone `pull_request_review`, `buildPrompt()` tells OpenCode to return the hidden marker `<!-- bonk: no actionable findings -->` instead of `LGTM!` when there are no findings.
- `test/github-script.spec.ts`: cases for the directive on reviews, and its absence when the input is off, on `issue_comment`, and on inline review-thread replies.
- `README.md`: documents `suppress_lgtm`, backfills the missing `forks` row.
- how do we know if bonk ran or not? - i'm assuming the ci step is the source of truth. so if it passes, then bonk ran

The marker is hidden HTML, so GitHub renders it invisibly; it mirrors the existing `FORK_COMMENT_MARKER` pattern. `issue_comment` (the `/bonk` trigger) and thread replies are not suppressed, so direct questions still get answered.