### PR TITLE
Refactor PR review to use checks and line comments

### DIFF
--- a/github/action.yml
+++ b/github/action.yml
@@ -245,6 +245,9 @@ runs:
         # Pass issue/PR context so the server can post failure comments even
         # when the run was never tracked or was already removed from activeRuns.
         ISSUE_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+        # PR context for creating a Bonk review check run.
+        HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.pull_request && github.event.issue.number || '' }}
       run: bun run ${{ github.action_path }}/script/finalize.ts
 
     - name: Cleanup Git credentials

--- a/github/bonk_guidance.md
+++ b/github/bonk_guidance.md
@@ -22,14 +22,14 @@ Bonk prepares the target before the run. After the final response, `opencode git
 - Do not create or switch branches, stage, commit, push, or create a pull request for working-tree changes.
 - Do not claim post-response lifecycle actions have already happened.
 - The `opencode github run` CLI, not the model, owns delivery of the top-level issue or pull request response. Return that response as final text; do not publish it through `gh` or the GitHub API.
-- For an ordinary code review, the only GitHub write you may make is one `COMMENT` review containing actionable inline comments and an empty body. Inspect existing reviews first, do not repeat a published finding, and do not submit a review without an inline finding.
+- For an ordinary code review, submit exactly one review using the GitHub pull request review API. Use `REQUEST_CHANGES` if there are actionable findings; use `APPROVE` if there are none. The review body must be empty. Inspect existing reviews first and do not repeat a published finding.
 - For any other GitHub mutation, require an explicit user request, inspect existing state, and use the exact repository and target from `<bonk_execution_context>`.
 
 ## Review completion
 
 - Report only discrete, actionable problems introduced by the change. Ignore non-blocking style preferences and speculative concerns.
-- Use an inline comment only when an exact changed line materially improves the finding. Submit all inline findings in the single empty-body review.
-- In the final response, list actionable findings not posted inline. If inline findings were submitted, state their count without repeating them.
-- If the review found no actionable issues at all, return exactly `LGTM!`.
+- For each inline finding, prefer posting a suggestion block when the fix is a direct, mechanical code change (e.g. a one-to-few-line replacement). Format suggestions as a fenced code block with the language identifier `suggestion`. The suggestion block must contain exactly the replacement lines for the line(s) the comment is anchored to — do not include surrounding context lines. Use a plain inline comment when the fix requires broader reasoning or spans code not in the diff.
+- Consolidate all inline findings into the single review submission. Do not submit a review with no inline findings; if no findings apply, use `APPROVE` with an empty body and no inline comments.
+- In the final response, state whether the review was approved or requested changes, and list the count of inline findings without repeating them. If the review was approved, return exactly `LGTM!`.
 
 If `working_tree` is `read-only`, do not edit or intentionally regenerate files. If a requested change requires writes, explain the limitation and describe the required change.

--- a/github/script/finalize.ts
+++ b/github/script/finalize.ts
@@ -27,6 +27,10 @@ async function main() {
 
   const apiBase = getApiBaseUrl();
 
+  const headSha = process.env.HEAD_SHA?.trim() || undefined;
+  const prNumberRaw = process.env.PR_NUMBER?.trim();
+  const prNumber = prNumberRaw ? parseInt(prNumberRaw, 10) || undefined : undefined;
+
   try {
     const response = await fetchWithRetry(`${apiBase}/api/github/track`, {
       method: "PUT",
@@ -43,6 +47,8 @@ async function main() {
         // run was never tracked or was already removed from activeRuns.
         issue_number: context.issue?.number,
         run_url: context.runUrl,
+        // PR context for creating a Bonk review check run.
+        ...(headSha && prNumber ? { head_sha: headSha, pr_number: prNumber } : {}),
       }),
     });
 

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -7,6 +7,8 @@ import {
   createReviewCommentReply,
   updateReviewComment,
   getWorkflowRunStatus,
+  upsertReviewCheckRun,
+  type CheckRunConclusion,
   type ReactionTarget,
 } from "./github";
 import { createLogger, sanitizeSecrets, type Logger } from "./log";
@@ -239,6 +241,8 @@ export class RepoAgent extends Agent<Env, RepoAgentState> {
     fallbackIssueNumber?: number,
     fallbackRunUrl?: string,
     actor?: string,
+    headSha?: string,
+    prNumber?: number,
   ): Promise<void> {
     const run = this.state.activeRuns[runId];
     const issueNumber = run?.issueNumber ?? fallbackIssueNumber;
@@ -262,15 +266,12 @@ export class RepoAgent extends Agent<Env, RepoAgentState> {
       log.warn("run_not_active_posting_failure", {
         recently_finalized: !!this.state.recentlyFinalizedRuns?.[runId],
       });
-      await this.postFailureComment(
-        runId,
-        fallbackRunUrl,
-        issueNumber,
-        status,
-        undefined,
-        undefined,
-        actor,
-      );
+      await Promise.all([
+        this.postFailureComment(runId, fallbackRunUrl, issueNumber, status, undefined, undefined, actor),
+        headSha && prNumber
+          ? this.postReviewCheckRun(headSha, prNumber, status, log)
+          : Promise.resolve(),
+      ]);
       return;
     }
 
@@ -278,6 +279,9 @@ export class RepoAgent extends Agent<Env, RepoAgentState> {
 
     if (status === "success") {
       log.info("run_completed_no_comment", { status });
+      if (headSha && prNumber) {
+        await this.postReviewCheckRun(headSha, prNumber, status, log);
+      }
       return;
     }
 
@@ -287,7 +291,44 @@ export class RepoAgent extends Agent<Env, RepoAgentState> {
     // failed and should be treated as a failure. The finalize script remaps
     // "skipped" -> "failure" client-side, but we also handle it here as
     // defense-in-depth.
-    await this.postFailureComment(runId, run.runUrl, run.issueNumber, status, run);
+    await Promise.all([
+      this.postFailureComment(runId, run.runUrl, run.issueNumber, status, run),
+      headSha && prNumber
+        ? this.postReviewCheckRun(headSha, prNumber, status, log)
+        : Promise.resolve(),
+    ]);
+  }
+
+  // Creates or updates the Bonk review check run on the PR head SHA.
+  // Best-effort: logs but does not throw on failure so it never blocks finalization.
+  private async postReviewCheckRun(
+    headSha: string,
+    prNumber: number,
+    status: string,
+    log: Logger,
+  ): Promise<void> {
+    // Map Bonk run status to a check run conclusion.
+    // success → success (approved), everything else → failure (requested changes or infra error).
+    const conclusion: CheckRunConclusion = status === "success" ? "success" : "failure";
+    const summary =
+      status === "success"
+        ? "Bonk reviewed this pull request and found no actionable issues."
+        : "Bonk reviewed this pull request and requested changes, or the run failed.";
+
+    let octokit: Octokit;
+    try {
+      octokit = await this.getOctokit();
+    } catch (error) {
+      log.errorWithException("check_run_octokit_failed", error, { pr_number: prNumber });
+      return;
+    }
+
+    try {
+      await upsertReviewCheckRun(octokit, this.owner, this.repo, headSha, conclusion, summary);
+      log.info("check_run_posted", { conclusion, pr_number: prNumber });
+    } catch (error) {
+      log.errorWithException("check_run_post_failed", error, { pr_number: prNumber });
+    }
   }
 
   async checkWorkflowStatus(payload: CheckStatusPayload): Promise<void> {

--- a/src/github-workflow-jobs.ts
+++ b/src/github-workflow-jobs.ts
@@ -247,7 +247,15 @@ export async function runFinalizeWorkflowJob(
   try {
     const agent = await getAgentByName<Env, RepoAgent>(env.REPO_AGENT, `${body.owner}/${body.repo}`);
     await agent.setInstallationId(installationId, installationSource);
-    await agent.finalizeRun(body.run_id, body.status, body.issue_number, body.run_url, actor);
+    await agent.finalizeRun(
+      body.run_id,
+      body.status,
+      body.issue_number,
+      body.run_url,
+      actor,
+      body.head_sha,
+      body.pr_number,
+    );
 
     finalizeLog.info("finalize_completed", {
       installation_id: installationId,

--- a/src/github.ts
+++ b/src/github.ts
@@ -740,6 +740,54 @@ export async function getWorkflowRunStatus(
   };
 }
 
+export type CheckRunConclusion = "success" | "failure" | "cancelled" | "skipped" | "neutral";
+
+// Creates or updates a Bonk review check run on the PR head SHA.
+// If an existing check run ID is provided, it updates that run; otherwise it creates a new one.
+// Returns the check run ID so callers can update it later.
+export async function upsertReviewCheckRun(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  headSha: string,
+  conclusion: CheckRunConclusion,
+  summary: string,
+  existingCheckRunId?: number,
+): Promise<number> {
+  const completedAt = new Date().toISOString();
+
+  if (existingCheckRunId) {
+    const response = await octokit.checks.update({
+      owner,
+      repo,
+      check_run_id: existingCheckRunId,
+      status: "completed",
+      conclusion,
+      completed_at: completedAt,
+      output: {
+        title: conclusion === "success" ? "Review passed" : "Review requested changes",
+        summary,
+      },
+    });
+    return response.data.id;
+  }
+
+  const response = await octokit.checks.create({
+    owner,
+    repo,
+    name: "Bonk Review",
+    head_sha: headSha,
+    status: "completed",
+    conclusion,
+    completed_at: completedAt,
+    output: {
+      title: conclusion === "success" ? "Review passed" : "Review requested changes",
+      summary,
+    },
+  });
+  return response.data.id;
+}
+
 // Delete a GitHub App installation. Used to reject installations from orgs not in ALLOWED_ORGS.
 // Requires app-level (JWT) authentication, not installation-level.
 export async function deleteInstallation(env: Env, installationId: number): Promise<void> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -203,6 +203,10 @@ export interface FinalizeWorkflowRequest {
   // removed it before the action's finalize step ran).
   issue_number?: number;
   run_url?: string;
+  // PR head SHA and number used to create or update a Bonk check run.
+  // Only present for pull_request / pull_request_review_comment events.
+  head_sha?: string;
+  pr_number?: number;
 }
 
 // Request to check/create workflow file (POST /api/github/setup)


### PR DESCRIPTION
👋🏻 @elithrar Thoughts on reworking the PR flow to use line comments and check runs? When you get back a handful of suggestions from the PR review, the big comment body can be a little clumsy to respond to. Line comments give you an individual thread for each comment, and the ability to drop inline suggestions. Check runs let you block the PR merge as appropriate. 

I don't have a test environment set up to validate the changes yet, but wanted to kick the conversation! 